### PR TITLE
Fix all broken unit tests

### DIFF
--- a/include/revolution/AI/ai_hardware.h
+++ b/include/revolution/AI/ai_hardware.h
@@ -12,7 +12,8 @@ extern "C" {
 volatile u32 AI_HW_REGS[]
 #ifdef __MWERKS__ 
 : 0xCD006C00
-#endif;
+#endif
+;
 
 /**
  * Hardware register indexes

--- a/include/revolution/FA/FA.h
+++ b/include/revolution/FA/FA.h
@@ -7,7 +7,7 @@ extern "C" {
 
 typedef void FAHandle;
 
-struct FAEntryInfo {
+typedef struct FAEntryInfo {
     char _0x0[0x224];
     s16 modifiedTime;
     s16 modifiedDate;
@@ -16,7 +16,7 @@ struct FAEntryInfo {
     char shortname[0xd];
     char name[0x38];
     char unk[0x1e2];
-};
+} FAEntryInfo;
 
 #ifdef __cplusplus
 }

--- a/include/revolution/FA/FAFstat.h
+++ b/include/revolution/FA/FAFstat.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-struct FAStat {
+typedef struct FAStat {
     int filesize;
     s16 accessDate;
     s16 modifiedTime;
@@ -14,7 +14,7 @@ struct FAStat {
     s16 createdDate;
     u16 unk;
     char flags;
-};
+} FAStat;
 
 int FAFstat(const char* filepath, FAStat* st);
 

--- a/include/revolution/SO/SOBasic.h
+++ b/include/revolution/SO/SOBasic.h
@@ -9,10 +9,10 @@ extern "C" {
 
 typedef void* (*alloc_t)(int, size_t);
 typedef void (*free_t)(int, void*);
-struct SOInitInfo {
+typedef struct SOInitInfo {
     alloc_t allocator;
     free_t dealloc;
-};
+} SOInitInfo;
 
 void SOFree(int, void*);
 void* SOAlloc(int, size_t);

--- a/include/revolution/VF/pf.h
+++ b/include/revolution/VF/pf.h
@@ -10,15 +10,15 @@ typedef enum {
     PF_RESULT_INVALID = 10,
 } PFResult;
 
-struct PF_ENT_ITER {
+typedef struct PF_ENT_ITER {
     char _0x0[0x8];
     u32 _0x8;
     char _0xC[0x2c];
     void* unk;
     char _0x3c[0x31];
-};
+} PF_ENT_ITER;
 
-struct PF_DIR_ENT {
+typedef struct PF_DIR_ENT {
     char _0x0[0x228];
     u32 _0x228;
     void* cache;
@@ -26,7 +26,7 @@ struct PF_DIR_ENT {
     u32 _0x234;
     int sector;
     short offset;
-};
+} PF_DIR_ENT;
 
 #ifdef __cplusplus
 }

--- a/include/stl/internal/wstring.h
+++ b/include/stl/internal/wstring.h
@@ -9,20 +9,7 @@ size_t wcslen(const wchar_t*);
 wchar_t* wcscpy(wchar_t*, const wchar_t*);
 wchar_t* wcsncpy(wchar_t*, const wchar_t*, size_t);
 wchar_t* wcscat(wchar_t*, const wchar_t*);
-int wcscmp(const wchar_t* s1, const wchar_t* s2) {
-    wchar_t c1, c2;
-
-    do
-    {
-        c1 = *s1++;
-        c2 = *s2++;
-        if (c2 == L'\0')
-            return c1 - c2;
-    }
-    while (c1 == c2);
-
-    return c1 < c2 ? -1 : 1;
-};
+int wcscmp(const wchar_t* s1, const wchar_t* s2);
 wchar_t* wcschr(const wchar_t*, wchar_t);
 
 #ifdef __cplusplus

--- a/src/stl/wstring.c
+++ b/src/stl/wstring.c
@@ -1,0 +1,16 @@
+#include "internal/wstring.h"
+
+int wcscmp(const wchar_t* s1, const wchar_t* s2) {
+    wchar_t c1, c2;
+
+    do
+    {
+        c1 = *s1++;
+        c2 = *s2++;
+        if (c2 == L'\0')
+            return c1 - c2;
+    }
+    while (c1 == c2);
+
+    return c1 < c2 ? -1 : 1;
+};


### PR DESCRIPTION
`tools/tester/tester.py --run=all` is now passing for all unit tests. A new `--compilers` option has also been added to the script, so the user can plug in the path to the GC/Wii compilers:

Test command line:
`$ python3 tools/tester/tester.py --compilers=../dtk-brawl/build/compilers --run=all`

Results:
![image](https://github.com/user-attachments/assets/a1a1729a-b92b-4cb3-81dd-ab68522ef4f7)
