### PR TITLE
Add support for nullptr to types.h for C++98 compilers

### DIFF
--- a/include/revolution/GX/GXTransform.h
+++ b/include/revolution/GX/GXTransform.h
@@ -37,10 +37,10 @@ void __GXSetProjection(void);
 void __GXSetViewport(void);
 void __GXSetMatrixIndex(GXAttr index);
 
-static void GXSetViewportv(const f32* vp);
-//{
-//    GXSetViewport(vp[0], vp[1], vp[2], vp[3], vp[4], vp[5]);
-//}
+inline void GXSetViewportv(const f32* vp)
+{
+   GXSetViewport(vp[0], vp[1], vp[2], vp[3], vp[4], vp[5]);
+}
 
 #ifdef __cplusplus
 }

--- a/include/revolution/MEM/mem_expHeap.h
+++ b/include/revolution/MEM/mem_expHeap.h
@@ -60,20 +60,20 @@ void MEMFreeToExpHeap(MEMiHeapHead* heap, void* memBlock);
 u32 MEMGetAllocatableSizeForExpHeapEx(MEMiHeapHead* heap, s32 align);
 u32 MEMAdjustExpHeap(MEMiHeapHead* heap);
 
-static MEMiHeapHead* MEMCreateExpHeap(void* start, u32 size);
-//{
-//    return MEMCreateExpHeapEx(start, size, 0);
-//}
+inline MEMiHeapHead* MEMCreateExpHeap(void* start, u32 size)
+{
+   return MEMCreateExpHeapEx(start, size, 0);
+}
 
-static void* MEMAllocFromExpHeap(MEMiHeapHead* heap, u32 size);
-//{
-//    return MEMAllocFromExpHeapEx(heap, size, 4);
-//}
+inline void* MEMAllocFromExpHeap(MEMiHeapHead* heap, u32 size)
+{
+   return MEMAllocFromExpHeapEx(heap, size, 4);
+}
 
-static u32 MEMGetAllocatableSizeForExpHeap(MEMiHeapHead* heap);
-//{
-//    return MEMGetAllocatableSizeForExpHeapEx(heap, 4);
-//}
+inline u32 MEMGetAllocatableSizeForExpHeap(MEMiHeapHead* heap)
+{
+   return MEMGetAllocatableSizeForExpHeapEx(heap, 4);
+}
 
 #ifdef __cplusplus
 }

--- a/include/revolution/MEM/mem_frameHeap.h
+++ b/include/revolution/MEM/mem_frameHeap.h
@@ -42,20 +42,20 @@ BOOL MEMFreeByStateToFrmHeap(MEMiHeapHead* heap, u32 id);
 u32 MEMAdjustFrmHeap(MEMiHeapHead* heap);
 u32 MEMResizeForMBlockFrmHeap(MEMiHeapHead* heap, void* memBlock, u32 size);
 
-static MEMiHeapHead* MEMCreateFrmHeap(void* start, u32 size);
-//{
-//    return MEMCreateFrmHeapEx(start, size, 0);
-//}
+inline MEMiHeapHead* MEMCreateFrmHeap(void* start, u32 size)
+{
+   return MEMCreateFrmHeapEx(start, size, 0);
+}
 
-static void* MEMAllocFromFrmHeap(MEMiHeapHead* heap, u32 size);
-//{
-//    return MEMAllocFromFrmHeapEx(heap, size, 4);
-//}
+inline void* MEMAllocFromFrmHeap(MEMiHeapHead* heap, u32 size)
+{
+   return MEMAllocFromFrmHeapEx(heap, size, 4);
+}
 
-static u32 MEMGetAllocatableSizeForFrmHeap(MEMiHeapHead* heap);
-//{
-//    return MEMGetAllocatableSizeForFrmHeapEx(heap, 4);
-//}
+inline u32 MEMGetAllocatableSizeForFrmHeap(MEMiHeapHead* heap)
+{
+   return MEMGetAllocatableSizeForFrmHeapEx(heap, 4);
+}
 
 #ifdef __cplusplus
 }

--- a/include/revolution/types.h
+++ b/include/revolution/types.h
@@ -36,4 +36,20 @@ typedef int BOOL;
 
 typedef void (*funcptr_t)(void);
 
+#if defined(__cplusplus) && __cplusplus < 201103L
+namespace std {
+class nullptr_t {
+    void operator&() const;
+public:
+    template<typename T>
+    operator T*() const { return 0; }
+
+    template<typename C, typename T>
+    operator T C::*() const { return 0; }
+};
+}
+
+const std::nullptr_t nullptr = {};
+#endif
+
 #endif


### PR DESCRIPTION
Also, fixed a unit test breakage involving mem_expHeap.h